### PR TITLE
Add Homebrew release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,278 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: macos-15
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Read release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must look like v1.2.3: $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          source packages/app/scripts/app-metadata.sh
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
+
+      - name: Check release credentials
+        shell: bash
+        env:
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          DEVELOPER_ID_CERTIFICATE: ${{ secrets.DEVELOPER_ID_CERTIFICATE }}
+          DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for name in \
+            APPLE_API_ISSUER_ID \
+            APPLE_API_KEY_ID \
+            APPLE_API_PRIVATE_KEY \
+            DEVELOPER_ID_CERTIFICATE \
+            DEVELOPER_ID_CERTIFICATE_PASSWORD
+          do
+            if [[ -z "${!name}" ]]; then
+              echo "Missing GitHub Actions secret: $name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Check release repository visibility
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          visibility="$(
+            gh repo view "$GITHUB_REPOSITORY" \
+              --json visibility \
+              --jq .visibility
+          )"
+          if [[ "$visibility" != "PUBLIC" ]]; then
+            echo "$GITHUB_REPOSITORY must be public before publishing a Homebrew cask" >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: swift test --package-path packages/app
+
+      - name: Import Developer ID certificate
+        shell: bash
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE }}
+          CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          certificate_path="$RUNNER_TEMP/developer-id.p12"
+          keychain_path="$RUNNER_TEMP/app-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+
+          printf '%s' "$CERTIFICATE_BASE64" | base64 -D > "$certificate_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$certificate_path" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain_path"
+
+          identity="$(
+            security find-identity -v -p codesigning "$keychain_path" |
+              sed -n 's/.*"\(Developer ID Application:.*\)".*/\1/p' |
+              sed -n '1p'
+          )"
+          if [[ -z "$identity" ]]; then
+            echo "The certificate does not contain a Developer ID Application identity" >&2
+            exit 1
+          fi
+          echo "CODESIGN_IDENTITY=$identity" >> "$GITHUB_ENV"
+
+      - name: Prepare notarization key
+        shell: bash
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          key_dir="$RUNNER_TEMP/private_keys"
+          key_path="$key_dir/AuthKey_${APPLE_API_KEY_ID}.p8"
+          mkdir -p "$key_dir"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Build signed Universal app
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="$RUNNER_TEMP/release"
+          VERSION="$VERSION" \
+          BUILD_NUMBER="$GITHUB_RUN_NUMBER" \
+          ARCHS="arm64 x86_64" \
+          OUTPUT_DIR="$output_dir" \
+          CODESIGN_IDENTITY="$CODESIGN_IDENTITY" \
+            packages/app/scripts/build-app.sh
+          echo "APP_PATH=$output_dir/$APP_NAME.app" >> "$GITHUB_ENV"
+
+      - name: Notarize app
+        shell: bash
+        env:
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          set -euo pipefail
+          submission="$RUNNER_TEMP/$APP_NAME-notarization.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$submission"
+          xcrun notarytool submit "$submission" \
+            --key "$APPLE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          spctl --assess --type execute --verbose=2 "$APP_PATH"
+
+      - name: Package release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          dist_dir="$GITHUB_WORKSPACE/dist"
+          archive="$dist_dir/$APP_NAME-$VERSION.zip"
+          checksum="$archive.sha256"
+          mkdir -p "$dist_dir"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$archive"
+          sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          printf '%s  %s\n' "$sha256" "$(basename "$archive")" > "$checksum"
+          echo "ARCHIVE=$archive" >> "$GITHUB_ENV"
+          echo "CHECKSUM=$checksum" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" \
+              "$ARCHIVE" \
+              "$CHECKSUM" \
+              --clobber \
+              --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "$ARCHIVE" \
+              "$CHECKSUM" \
+              --generate-notes \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$APP_NAME $VERSION" \
+              --verify-tag
+          fi
+
+  update-tap:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: homebrew-tap-update
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Read release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          source packages/app/scripts/app-metadata.sh
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
+
+      - name: Read release checksum
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          checksum_dir="$RUNNER_TEMP/checksum"
+          checksum="$checksum_dir/$APP_NAME-$VERSION.zip.sha256"
+          mkdir -p "$checksum_dir"
+          gh release download "$GITHUB_REF_NAME" \
+            --dir "$checksum_dir" \
+            --pattern "$APP_NAME-*.zip.sha256" \
+            --repo "$GITHUB_REPOSITORY"
+          read -r sha256 _ < "$checksum"
+          if [[ ! "$sha256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Invalid release SHA-256: $sha256" >&2
+            exit 1
+          fi
+          echo "SHA256=$sha256" >> "$GITHUB_ENV"
+
+      - name: Update Homebrew tap
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+          TAP_REPOSITORY: jomatsu/homebrew-tap
+        run: |
+          set -euo pipefail
+          if [[ -z "$HOMEBREW_TAP_DEPLOY_KEY" ]]; then
+            echo "Missing GitHub Actions secret: HOMEBREW_TAP_DEPLOY_KEY" >&2
+            exit 1
+          fi
+
+          ssh_dir="$RUNNER_TEMP/ssh"
+          key_path="$ssh_dir/id_ed25519"
+          known_hosts="$ssh_dir/known_hosts"
+          tap_dir="$RUNNER_TEMP/homebrew-tap"
+          mkdir -p "$ssh_dir"
+          printf '%s\n' "$HOMEBREW_TAP_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          gh api meta --jq '.ssh_keys[] | "github.com " + .' > "$known_hosts"
+          export GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+
+          git clone --depth 1 "git@github.com:$TAP_REPOSITORY.git" "$tap_dir"
+          RELEASE_REPOSITORY="$GITHUB_REPOSITORY" \
+            packages/app/scripts/render-cask.sh \
+              "$VERSION" \
+              "$SHA256" \
+              "$tap_dir/Casks/aerokit.rb"
+
+          git -C "$tap_dir" config user.name "github-actions[bot]"
+          git -C "$tap_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$tap_dir" add Casks/aerokit.rb
+          if git -C "$tap_dir" diff --cached --quiet; then
+            echo "Homebrew cask is already up to date"
+            exit 0
+          fi
+          git -C "$tap_dir" commit -m "aerokit $VERSION"
+          git -C "$tap_dir" push origin HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .build/
 .swiftpm/
+dist/
 DerivedData/
 *.xcodeproj
 *.xcworkspace

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ a Cmd-Tab-style **workspace switcher** with snapshot previews, and an Exposé-st
 Build and install from source:
 
 ```sh
-git clone https://github.com/Nasubikun/aerokit.git
+git clone https://github.com/jomatsu/aerokit.git
 cd aerokit/packages/app
 scripts/install-app.sh
 ```
@@ -32,9 +32,9 @@ scripts/install-app.sh
 This builds a release binary, wraps it into `~/Applications/AeroKit.app`, and
 registers a LaunchAgent so it starts at login.
 
-<!-- TODO: once the Homebrew tap is live:
+<!-- TODO: enable after the first signed release:
 ```sh
-brew install --cask nasubikun/tap/aerokit
+brew install --cask jomatsu/tap/aerokit
 ```
 -->
 
@@ -58,6 +58,9 @@ make check      # lint + build + test
 ```
 
 Formatting and linting rules are shared across packages via the root `.swiftformat` and `.swiftlint.yml`.
+
+Release maintainers should follow [`docs/releasing.md`](docs/releasing.md) for
+Developer ID signing, notarization, GitHub Releases, and Homebrew tap updates.
 
 ## License
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,79 @@
+# Releasing AeroKit
+
+A release tag builds a Universal macOS app, signs it with Developer ID,
+notarizes it, publishes a GitHub Release, and updates
+`jomatsu/homebrew-tap`.
+
+## One-time setup
+
+The release repository and every release asset referenced by the cask must be
+publicly downloadable. The current workflow publishes to `jomatsu/aerokit`, so
+that repository must be public before the first release tag is pushed.
+
+Create the tap repository with Homebrew's generated CI files:
+
+```sh
+brew tap-new jomatsu/tap
+gh repo create jomatsu/homebrew-tap \
+  --public \
+  --source "$(brew --repository jomatsu/tap)" \
+  --push
+```
+
+Configure these Actions secrets in `jomatsu/aerokit`:
+
+| Secret | Value |
+| --- | --- |
+| `DEVELOPER_ID_CERTIFICATE` | Base64-encoded `.p12` containing a Developer ID Application certificate and private key |
+| `DEVELOPER_ID_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+| `APPLE_API_KEY_ID` | App Store Connect API key ID |
+| `APPLE_API_ISSUER_ID` | App Store Connect API issuer ID |
+| `APPLE_API_PRIVATE_KEY` | Complete contents of the matching `AuthKey_*.p8` file |
+| `HOMEBREW_TAP_DEPLOY_KEY` | Private half of a write-enabled deploy key scoped to `jomatsu/homebrew-tap` |
+
+On macOS, encode an exported certificate and set the secrets with `gh`:
+
+```sh
+base64 -i DeveloperID.p12 | gh secret set DEVELOPER_ID_CERTIFICATE -R jomatsu/aerokit
+gh secret set DEVELOPER_ID_CERTIFICATE_PASSWORD -R jomatsu/aerokit
+gh secret set APPLE_API_KEY_ID -R jomatsu/aerokit
+gh secret set APPLE_API_ISSUER_ID -R jomatsu/aerokit
+gh secret set APPLE_API_PRIVATE_KEY -R jomatsu/aerokit < AuthKey_KEYID.p8
+```
+
+Use a dedicated write-enabled deploy key for the tap, and store its private
+half as `HOMEBREW_TAP_DEPLOY_KEY`. Do not reuse a personal SSH key or a broad
+GitHub access token.
+
+## Publish a version
+
+Run the full local check, then push a semantic-version tag:
+
+```sh
+make check
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The release workflow rejects tags that do not look like `v1.2.3`. It will not
+publish an unsigned or unnotarized build.
+
+After the workflow completes, verify installation from a clean machine:
+
+```sh
+brew install --cask jomatsu/tap/aerokit
+brew uninstall --cask aerokit
+```
+
+## Local app bundle
+
+`build-app.sh` defaults to an ad-hoc signature for local builds. Release builds
+must provide a Developer ID identity explicitly.
+
+```sh
+VERSION=0.1.0 \
+ARCHS="arm64 x86_64" \
+OUTPUT_DIR="$PWD/dist" \
+CODESIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
+  packages/app/scripts/build-app.sh
+```

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -74,6 +74,12 @@ carry over automatically.
 Grant **Screen Recording** in the settings window when prompted — previews
 need it (the apps still work without it, minus previews).
 
+To build an app bundle without installing or launching it:
+
+```sh
+VERSION=0.1.0 scripts/build-app.sh
+```
+
 CLI entry points for scripting / AeroSpace keybindings:
 
 ```sh

--- a/packages/app/scripts/app-metadata.sh
+++ b/packages/app/scripts/app-metadata.sh
@@ -1,0 +1,4 @@
+APP_NAME="AeroKit"
+BUNDLE_ID="com.nasubikun.aerokit"
+MINIMUM_MACOS_VERSION="14.0"
+MINIMUM_MACOS_CASK="sonoma"

--- a/packages/app/scripts/build-app.sh
+++ b/packages/app/scripts/build-app.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/app-metadata.sh"
+
+VERSION="${VERSION:-0.1.0}"
+BUILD_NUMBER="${BUILD_NUMBER:-1}"
+ARCHS="${ARCHS:-$(uname -m)}"
+OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/dist}"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "VERSION must be a semantic version without a leading v: $VERSION" >&2
+  exit 1
+fi
+
+if [[ ! "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "BUILD_NUMBER must be an integer: $BUILD_NUMBER" >&2
+  exit 1
+fi
+
+read -r -a BUILD_ARCHS <<< "$ARCHS"
+if [[ "${#BUILD_ARCHS[@]}" -eq 0 ]]; then
+  echo "ARCHS must contain at least one architecture" >&2
+  exit 1
+fi
+
+BUILD_ARGS=(-c release --product "$APP_NAME")
+for arch in "${BUILD_ARCHS[@]}"; do
+  case "$arch" in
+    arm64|x86_64) BUILD_ARGS+=(--arch "$arch") ;;
+    *)
+      echo "Unsupported architecture: $arch" >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$ROOT_DIR"
+swift build "${BUILD_ARGS[@]}"
+BIN_DIR="$(swift build "${BUILD_ARGS[@]}" --show-bin-path)"
+BINARY="$BIN_DIR/$APP_NAME"
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "Built executable not found: $BINARY" >&2
+  exit 1
+fi
+
+APP_DIR="$OUTPUT_DIR/$APP_NAME.app"
+CONTENTS_DIR="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+
+rm -rf "$APP_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+install -m 755 "$BINARY" "$MACOS_DIR/$APP_NAME"
+
+cat > "$CONTENTS_DIR/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleExecutable</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleIdentifier</key>
+  <string>$BUNDLE_ID</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$VERSION</string>
+  <key>CFBundleVersion</key>
+  <string>$BUILD_NUMBER</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>$MINIMUM_MACOS_VERSION</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
+
+if [[ "$CODESIGN_IDENTITY" == "auto" ]]; then
+  CODESIGN_IDENTITY="$(
+    security find-identity -v -p codesigning 2>/dev/null |
+      sed -n 's/.*"\(Apple Development:.*\)".*/\1/p' |
+      sed -n '1p'
+  )"
+  CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+fi
+
+SIGN_ARGS=(--force --sign "$CODESIGN_IDENTITY")
+if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+  SIGN_ARGS+=(--options runtime --timestamp)
+fi
+codesign "${SIGN_ARGS[@]}" "$APP_DIR"
+codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+
+printf '%s\n' "$APP_DIR"

--- a/packages/app/scripts/install-app.sh
+++ b/packages/app/scripts/install-app.sh
@@ -2,72 +2,19 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-APP_NAME="AeroKit"
-BUNDLE_ID="com.nasubikun.aerokit"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/app-metadata.sh"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/Applications}"
 APP_DIR="$INSTALL_DIR/$APP_NAME.app"
-CONTENTS_DIR="$APP_DIR/Contents"
-MACOS_DIR="$CONTENTS_DIR/MacOS"
-RESOURCES_DIR="$CONTENTS_DIR/Resources"
 LAUNCH_AGENT_DIR="$HOME/Library/LaunchAgents"
 LAUNCH_AGENT="$LAUNCH_AGENT_DIR/$BUNDLE_ID.plist"
 LOG_DIR="$HOME/Library/Logs/$APP_NAME"
 
-cd "$ROOT_DIR"
-
-swift build -c release --product "$APP_NAME"
-BIN_DIR="$(swift build -c release --show-bin-path)"
-BINARY="$BIN_DIR/$APP_NAME"
-
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$LAUNCH_AGENT_DIR" "$LOG_DIR"
-rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
-cp "$BINARY" "$MACOS_DIR/$APP_NAME"
-
-cat > "$CONTENTS_DIR/Info.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleExecutable</key>
-  <string>$APP_NAME</string>
-  <key>CFBundleIdentifier</key>
-  <string>$BUNDLE_ID</string>
-  <key>CFBundleName</key>
-  <string>$APP_NAME</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
-  <key>CFBundleVersion</key>
-  <string>1</string>
-  <key>LSMinimumSystemVersion</key>
-  <string>14.0</string>
-  <key>LSUIElement</key>
-  <true/>
-  <key>NSHighResolutionCapable</key>
-  <true/>
-</dict>
-</plist>
-PLIST
-
-if command -v codesign >/dev/null 2>&1; then
-  CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-}"
-  if [[ -z "$CODESIGN_IDENTITY" ]] && command -v security >/dev/null 2>&1; then
-    CODESIGN_IDENTITY="$(
-      security find-identity -v -p codesigning 2>/dev/null |
-        sed -n 's/.*"\(Apple Development:.*\)".*/\1/p' |
-        head -n 1
-    )"
-  fi
-  if [[ -n "$CODESIGN_IDENTITY" ]]; then
-    codesign --force --deep --sign "$CODESIGN_IDENTITY" "$APP_DIR" >/dev/null
-  else
-    codesign --force --deep --sign - "$APP_DIR" >/dev/null
-  fi
-fi
+mkdir -p "$INSTALL_DIR" "$LAUNCH_AGENT_DIR" "$LOG_DIR"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-auto}" \
+  OUTPUT_DIR="$INSTALL_DIR" \
+  "$SCRIPT_DIR/build-app.sh" >/dev/null
 
 # Retire the pre-unification apps: their LaunchAgents, processes and bundles
 # are superseded by AeroKit.
@@ -80,29 +27,16 @@ for OLD_APP in AeroSwitcher AeroExpose; do
   rm -rf "$INSTALL_DIR/$OLD_APP.app"
 done
 
-cat > "$LAUNCH_AGENT" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>$BUNDLE_ID</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/bin/open</string>
-    <string>-g</string>
-    <string>$APP_DIR</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>StandardOutPath</key>
-  <string>$LOG_DIR/stdout.log</string>
-  <key>StandardErrorPath</key>
-  <string>$LOG_DIR/stderr.log</string>
-</dict>
-</plist>
-PLIST
+plutil -create xml1 "$LAUNCH_AGENT"
+plutil -insert Label -string "$BUNDLE_ID" "$LAUNCH_AGENT"
+plutil -insert ProgramArguments -array "$LAUNCH_AGENT"
+plutil -insert ProgramArguments.0 -string /usr/bin/open "$LAUNCH_AGENT"
+plutil -insert ProgramArguments.1 -string -g "$LAUNCH_AGENT"
+plutil -insert ProgramArguments.2 -string "$APP_DIR" "$LAUNCH_AGENT"
+plutil -insert RunAtLoad -bool true "$LAUNCH_AGENT"
+plutil -insert StandardOutPath -string "$LOG_DIR/stdout.log" "$LAUNCH_AGENT"
+plutil -insert StandardErrorPath -string "$LOG_DIR/stderr.log" "$LAUNCH_AGENT"
+plutil -lint "$LAUNCH_AGENT" >/dev/null
 
 launchctl bootout "gui/$(id -u)" "$LAUNCH_AGENT" >/dev/null 2>&1 || true
 /usr/bin/pkill -x "$APP_NAME" >/dev/null 2>&1 || true

--- a/packages/app/scripts/render-cask.sh
+++ b/packages/app/scripts/render-cask.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/app-metadata.sh"
+
+VERSION="${1:?Usage: render-cask.sh VERSION SHA256 OUTPUT}"
+SHA256="${2:?Usage: render-cask.sh VERSION SHA256 OUTPUT}"
+OUTPUT="${3:?Usage: render-cask.sh VERSION SHA256 OUTPUT}"
+RELEASE_REPOSITORY="${RELEASE_REPOSITORY:-jomatsu/aerokit}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Cask versions must be stable semantic versions: $VERSION" >&2
+  exit 1
+fi
+
+if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Invalid SHA-256: $SHA256" >&2
+  exit 1
+fi
+
+if [[ ! "$RELEASE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Invalid RELEASE_REPOSITORY: $RELEASE_REPOSITORY" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+cat > "$OUTPUT" <<CASK
+cask "aerokit" do
+  version "$VERSION"
+  sha256 "$SHA256"
+
+  url "https://github.com/$RELEASE_REPOSITORY/releases/download/v#{version}/$APP_NAME-#{version}.zip"
+  name "$APP_NAME"
+  desc "AeroSpace companion with workspace switching, Exposé, and trackpad navigation"
+  homepage "https://github.com/$RELEASE_REPOSITORY"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :$MINIMUM_MACOS_CASK
+
+  app "$APP_NAME.app"
+  binary "#{appdir}/$APP_NAME.app/Contents/MacOS/$APP_NAME", target: "aerokit"
+
+  uninstall launchctl: "$BUNDLE_ID",
+            quit:      "$BUNDLE_ID"
+
+  zap trash: [
+    "~/Library/Application Support/$APP_NAME",
+    "~/Library/Caches/$BUNDLE_ID",
+    "~/Library/LaunchAgents/$BUNDLE_ID.plist",
+    "~/Library/Logs/$APP_NAME",
+    "~/Library/Preferences/$BUNDLE_ID.plist",
+    "~/Library/Saved Application State/$BUNDLE_ID.savedState",
+  ]
+end
+CASK
+
+printf '%s\n' "$OUTPUT"


### PR DESCRIPTION
## Summary
- build a signed Universal AeroKit.app from SwiftPM
- notarize tagged releases and publish immutable zip/checksum assets
- update jomatsu/homebrew-tap through a scoped deploy key
- document the release and Homebrew workflow

## Validation
- 152 Swift tests passed, with 2 render tests skipped as expected
- Universal arm64/x86_64 app build and ad-hoc signature verified
- generated Cask passes brew style
- workflow YAML and shell syntax validated
- make check currently stops on pre-existing SwiftFormat violations in four unrelated Swift files

## Release prerequisites
- jomatsu/aerokit remains private; the workflow refuses to release until it is public
- Developer ID and App Store Connect secrets are intentionally not configured yet
- no release tag was created