### PR TITLE
ci: build releases on macOS 26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Check out source


### PR DESCRIPTION
## Summary

- run the release job on the GA macOS 26 arm64 image
- align CI with the Xcode 26 toolchain used by the passing local build

## Why

The v0.1.0 release run failed during Swift compilation on the macOS 15 image defaulting to Xcode 16.4, before signing or notarization.

## Validation

- release workflow YAML parses successfully
- git diff --check passes
- local Xcode 26 tests previously passed: 152 tests, 2 expected skips, 0 failures

After merge, publish a new v0.1.1 tag. The existing v0.1.0 tag will not be moved.